### PR TITLE
Add missing launch options

### DIFF
--- a/Nickel/Framework/Nickel.cs
+++ b/Nickel/Framework/Nickel.cs
@@ -35,7 +35,10 @@ internal sealed class Nickel
         );
 
         RootCommand rootCommand = new("Nickel -- A modding API / modloader for the game Cobalt Core.");
+        rootCommand.AddOption(debugOption);
+        rootCommand.AddOption(gamePathOption);
         rootCommand.AddOption(modsPathOption);
+        rootCommand.AddOption(savePathOption);
 
         rootCommand.SetHandler((InvocationContext context) =>
         {


### PR DESCRIPTION
These were declared, but not added to the command -- thus they were unusable.