### PR TITLE
Use normalized path names in .zip files

### DIFF
--- a/PluginManager/Implementations/ZipPluginPackage.cs
+++ b/PluginManager/Implementations/ZipPluginPackage.cs
@@ -9,11 +9,11 @@ namespace Nanoray.PluginManager;
 
 public sealed class ZipPluginPackage<TPluginManifest> : IPluginPackage<TPluginManifest>
 {
-	public TPluginManifest Manifest { get; init; }
-	public IReadOnlySet<string> DataEntries { get; init; }
+	public TPluginManifest Manifest { get; }
+	public IReadOnlySet<string> DataEntries { get; }
 	private IReadOnlyDictionary<string, string> DataMapping { get; }
 
-	private ZipArchive Archive { get; init; }
+	private ZipArchive Archive { get; }
 
 	public ZipPluginPackage(TPluginManifest manifest, ZipArchive archive)
 	{


### PR DESCRIPTION
---

Open TODOs:

- [ ] Formalize exception type for `GetDataStream` with a non-existent `entry`, and apply that to this PR