### PR TITLE
Add 'Will Edit Assembly' interface to AssemblyEditor

### DIFF
--- a/PluginManager.Cecil/Implementations/ExtendableAssemblyDefinitionEditor.cs
+++ b/PluginManager.Cecil/Implementations/ExtendableAssemblyDefinitionEditor.cs
@@ -6,15 +6,15 @@ namespace Nanoray.PluginManager.Cecil;
 
 public sealed class ExtendableAssemblyDefinitionEditor : IAssemblyEditor
 {
-	private List<IAssemblyDefinitionEditor> DefinitionEditors { get; } = [];
+	private readonly List<IAssemblyDefinitionEditor> definitionEditors = [];
 
 	public Stream EditAssemblyStream(string name, Stream assemblyStream)
 	{
-		if (this.DefinitionEditors.Count <= 0)
+		if (this.definitionEditors.Count <= 0)
 			return assemblyStream;
 
 		var definition = AssemblyDefinition.ReadAssembly(assemblyStream);
-		foreach (var definitionEditor in this.DefinitionEditors)
+		foreach (var definitionEditor in this.definitionEditors)
 			definitionEditor.EditAssemblyDefinition(definition);
 
 		MemoryStream newStream = new();
@@ -24,8 +24,8 @@ public sealed class ExtendableAssemblyDefinitionEditor : IAssemblyEditor
 	}
 
 	public void RegisterDefinitionEditor(IAssemblyDefinitionEditor definitionEditor)
-		=> this.DefinitionEditors.Add(definitionEditor);
+		=> this.definitionEditors.Add(definitionEditor);
 
 	public void UnregisterDefinitionEditor(IAssemblyDefinitionEditor definitionEditor)
-		=> this.DefinitionEditors.Remove(definitionEditor);
+		=> this.definitionEditors.Remove(definitionEditor);
 }

--- a/PluginManager.Cecil/Implementations/ExtendableAssemblyDefinitionEditor.cs
+++ b/PluginManager.Cecil/Implementations/ExtendableAssemblyDefinitionEditor.cs
@@ -1,6 +1,8 @@
 using Mono.Cecil;
+using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 
 namespace Nanoray.PluginManager.Cecil;
 
@@ -10,11 +12,12 @@ public sealed class ExtendableAssemblyDefinitionEditor : IAssemblyEditor
 
 	public Stream EditAssemblyStream(string name, Stream assemblyStream)
 	{
-		if (this.definitionEditors.Count <= 0)
+		var interestedEditors = this.definitionEditors.Where(x => x.WillEditAssembly(name)).ToList();
+		if (interestedEditors.Count <= 0)
 			return assemblyStream;
 
 		var definition = AssemblyDefinition.ReadAssembly(assemblyStream);
-		foreach (var definitionEditor in this.definitionEditors)
+		foreach (var definitionEditor in interestedEditors)
 			definitionEditor.EditAssemblyDefinition(definition);
 
 		MemoryStream newStream = new();

--- a/PluginManager.Cecil/Interfaces/IAssemblyDefinitionEditor.cs
+++ b/PluginManager.Cecil/Interfaces/IAssemblyDefinitionEditor.cs
@@ -4,5 +4,6 @@ namespace Nanoray.PluginManager.Cecil;
 
 public interface IAssemblyDefinitionEditor
 {
+	bool WillEditAssembly(string fileBaseName);
 	void EditAssemblyDefinition(AssemblyDefinition definition);
 }


### PR DESCRIPTION
Prevents issues when trying to write out native-mode Assemblies with Mono.Cecil.

---

Split from #46 