### PR TITLE
Load non-shared assemblies in the CustomContext, not the shared one

### DIFF
--- a/Nickel/Framework/Implementations/AssemblyModLoadContextProvider.cs
+++ b/Nickel/Framework/Implementations/AssemblyModLoadContextProvider.cs
@@ -77,11 +77,11 @@ internal sealed class AssemblyModLoadContextProvider(
 				try
 				{
 					using var assemblyStream = this.Package.PackageRoot.GetRelativeFile($"{assemblyName.Name ?? assemblyName.FullName}.dll").OpenRead();
-					return this.SharedContext.LoadFromStream(assemblyStream);
+					return this.LoadFromStream(assemblyStream);
 				}
 				catch
 				{
-					return this.SharedContext.LoadFromAssemblyName(assemblyName);
+					return this.LoadFromAssemblyName(assemblyName);
 				}
 			}
 		}


### PR DESCRIPTION
This fixes an issue where second-level dependencies (e.g. `Mod -> Lib1 -> Lib2`) wouldn't get loaded, as `Lib1` was loaded in the shared context rather than the mod-individual context.