### PR TITLE
Add Cecil Assembly Resolver

### DIFF
--- a/Nickel/Framework/Implementations/PackageAssemblyResolver.cs
+++ b/Nickel/Framework/Implementations/PackageAssemblyResolver.cs
@@ -1,0 +1,68 @@
+using Mono.Cecil;
+using Nanoray.PluginManager;
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace Nickel;
+
+internal class PackageAssemblyResolver(IReadOnlyList<IPluginPackage<IModManifest>> packages) : IAssemblyResolver
+{
+	private readonly Dictionary<string, AssemblyDefinition> cache = [];
+	private readonly List<Stream> openStreams = [];
+	private readonly DefaultAssemblyResolver fallbackResolver = new();
+
+
+	public void Dispose()
+	{
+		foreach (var assembly in this.cache.Values)
+			assembly.Dispose();
+		foreach (var stream in this.openStreams)
+			stream.Dispose();
+		this.fallbackResolver.Dispose();
+	}
+
+	public AssemblyDefinition Resolve(AssemblyNameReference name)
+	{
+		if (this.cache.TryGetValue(name.FullName, out var cached)) return cached;
+		return this.cache[name.FullName] = this.Resolve(name, new ReaderParameters());
+	}
+
+	public AssemblyDefinition Resolve(AssemblyNameReference name, ReaderParameters parameters)
+	{
+		parameters.AssemblyResolver ??= this;
+		var stream = this.GetStreamForAssembly(name);
+		if (stream == null)
+			return this.fallbackResolver.Resolve(name, parameters);
+
+		try
+		{
+			this.openStreams.Add(stream);
+		}
+		catch (Exception) { stream.Dispose(); throw; }
+
+		/* `DefaultAssemblyResolver` does this as well.
+		 * `AssemblyDefinition.ReadAssembly` does a similar thing internally, too.
+		 * Don't ask me why, ask the Cecil authors.
+		 */
+		return ModuleDefinition.ReadModule(stream, parameters).Assembly;
+	}
+
+	private Stream? GetStreamForAssembly(AssemblyNameReference name)
+	{
+		foreach(var package in packages)
+		{
+			try
+			{
+				return package.PackageRoot.GetRelativeFile(name.Name + ".dll").OpenRead();
+			} catch(FileNotFoundException) {}
+
+			try
+			{
+				return package.PackageRoot.GetRelativeFile(name.Name + ".exe").OpenRead();
+			} catch(FileNotFoundException) {}
+		}
+
+		return null;
+	}
+}

--- a/Nickel/Framework/Implementations/PackageAssemblyResolver.cs
+++ b/Nickel/Framework/Implementations/PackageAssemblyResolver.cs
@@ -12,7 +12,6 @@ internal class PackageAssemblyResolver(IReadOnlyList<IPluginPackage<IModManifest
 	private readonly List<Stream> openStreams = [];
 	private readonly DefaultAssemblyResolver fallbackResolver = new();
 
-
 	public void Dispose()
 	{
 		foreach (var assembly in this.cache.Values)
@@ -50,17 +49,19 @@ internal class PackageAssemblyResolver(IReadOnlyList<IPluginPackage<IModManifest
 
 	private Stream? GetStreamForAssembly(AssemblyNameReference name)
 	{
-		foreach(var package in packages)
+		foreach (var package in packages)
 		{
 			try
 			{
 				return package.PackageRoot.GetRelativeFile(name.Name + ".dll").OpenRead();
-			} catch(FileNotFoundException) {}
+			}
+			catch (FileNotFoundException) { }
 
 			try
 			{
 				return package.PackageRoot.GetRelativeFile(name.Name + ".exe").OpenRead();
-			} catch(FileNotFoundException) {}
+			}
+			catch (FileNotFoundException) { }
 		}
 
 		return null;

--- a/Nickel/Framework/Implementations/PackageAssemblyResolver.cs
+++ b/Nickel/Framework/Implementations/PackageAssemblyResolver.cs
@@ -23,7 +23,8 @@ internal class PackageAssemblyResolver(IReadOnlyList<IPluginPackage<IModManifest
 
 	public AssemblyDefinition Resolve(AssemblyNameReference name)
 	{
-		if (this.cache.TryGetValue(name.FullName, out var cached)) return cached;
+		if (this.cache.TryGetValue(name.FullName, out var cached))
+			return cached;
 		return this.cache[name.FullName] = this.Resolve(name, new ReaderParameters());
 	}
 
@@ -38,7 +39,11 @@ internal class PackageAssemblyResolver(IReadOnlyList<IPluginPackage<IModManifest
 		{
 			this.openStreams.Add(stream);
 		}
-		catch (Exception) { stream.Dispose(); throw; }
+		catch (Exception)
+		{
+			stream.Dispose();
+			throw;
+		}
 
 		/* `DefaultAssemblyResolver` does this as well.
 		 * `AssemblyDefinition.ReadAssembly` does a similar thing internally, too.

--- a/Nickel/Framework/ModManager.cs
+++ b/Nickel/Framework/ModManager.cs
@@ -30,7 +30,7 @@ internal sealed class ModManager
 	internal ContentManager? ContentManager { get; private set; }
 
 	private ExtendablePluginLoader<IModManifest, Mod> ExtendablePluginLoader { get; } = new();
-	private List<IPluginPackage<IModManifest>> ResolvedMods { get; } = [];
+	internal List<IPluginPackage<IModManifest>> ResolvedMods { get; } = [];
 	private List<IModManifest> FailedMods { get; } = [];
 	private HashSet<IModManifest> OptionalSubmods { get; } = [];
 

--- a/Nickel/Framework/Nickel.cs
+++ b/Nickel/Framework/Nickel.cs
@@ -118,7 +118,9 @@ internal sealed class Nickel
 		var modsDirectory = launchArguments.ModsPath ?? GetOrCreateDefaultModLibraryDirectory();
 		logger.LogInformation("ModsPath: {Path}", modsDirectory.FullName);
 
-		ExtendableAssemblyDefinitionEditor extendableAssemblyDefinitionEditor = new();
+		ExtendableAssemblyDefinitionEditor extendableAssemblyDefinitionEditor = new(() =>
+			new PackageAssemblyResolver(instance.ModManager.ResolvedMods)
+		);
 		extendableAssemblyDefinitionEditor.RegisterDefinitionEditor(new CobaltCorePublisher());
 		instance.ModManager = new(modsDirectory, loggerFactory, logger, extendableAssemblyDefinitionEditor);
 		instance.ModManager.ResolveMods();

--- a/PluginManager.Cecil/Implementations/ExtendableAssemblyDefinitionEditor.cs
+++ b/PluginManager.Cecil/Implementations/ExtendableAssemblyDefinitionEditor.cs
@@ -15,7 +15,7 @@ public sealed class ExtendableAssemblyDefinitionEditor : IAssemblyEditor
 		if (interestedEditors.Count <= 0)
 			return assemblyStream;
 
-		var definition = AssemblyDefinition.ReadAssembly(assemblyStream);
+		using var definition = AssemblyDefinition.ReadAssembly(assemblyStream);
 		foreach (var definitionEditor in interestedEditors)
 			definitionEditor.EditAssemblyDefinition(definition);
 

--- a/PluginManager.Cecil/Implementations/ExtendableAssemblyDefinitionEditor.cs
+++ b/PluginManager.Cecil/Implementations/ExtendableAssemblyDefinitionEditor.cs
@@ -1,11 +1,12 @@
 using Mono.Cecil;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 
 namespace Nanoray.PluginManager.Cecil;
 
-public sealed class ExtendableAssemblyDefinitionEditor : IAssemblyEditor
+public sealed class ExtendableAssemblyDefinitionEditor(Func<IAssemblyResolver> cecilAssemblyResolverProducer) : IAssemblyEditor
 {
 	private readonly List<IAssemblyDefinitionEditor> DefinitionEditors = [];
 
@@ -15,7 +16,8 @@ public sealed class ExtendableAssemblyDefinitionEditor : IAssemblyEditor
 		if (interestedEditors.Count <= 0)
 			return assemblyStream;
 
-		using var definition = AssemblyDefinition.ReadAssembly(assemblyStream);
+		using var assemblyResolver = cecilAssemblyResolverProducer();
+		using var definition = AssemblyDefinition.ReadAssembly(assemblyStream, new ReaderParameters { AssemblyResolver = assemblyResolver });
 		foreach (var definitionEditor in interestedEditors)
 			definitionEditor.EditAssemblyDefinition(definition);
 


### PR DESCRIPTION
This allows mods that use Cecil to patch the CobaltCore assembly to refer to mod assemblies when doing so.