### PR TITLE
Add mod-sprite lookup methods

### DIFF
--- a/Nickel/Framework/Content/SpriteManager.cs
+++ b/Nickel/Framework/Content/SpriteManager.cs
@@ -34,7 +34,7 @@ internal sealed class SpriteManager
 		var uniqueName = $"{owner.UniqueName}::{name}";
 		if (this.UniqueNameToEntry.ContainsKey(uniqueName))
 			throw new ArgumentException($"A sprite with the unique name `{uniqueName}` is already registered", nameof(name));
-		return this.RegisterSprite(new(owner, $"{owner.UniqueName}::{name}", (Spr)this.NextId++, streamProvider));
+		return this.RegisterSprite(new(owner, uniqueName, (Spr)this.NextId++, streamProvider));
 	}
 
 	private Entry RegisterSprite(Entry entry)

--- a/Nickel/Framework/Content/SpriteManager.cs
+++ b/Nickel/Framework/Content/SpriteManager.cs
@@ -1,25 +1,23 @@
 using Microsoft.Xna.Framework.Graphics;
 using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.IO;
+using System.Linq;
 
 namespace Nickel;
 
 internal sealed class SpriteManager
 {
 	private int NextId { get; set; } = 10_000_001;
+	private IModManifest VanillaModManifest { get; }
 	private Dictionary<Spr, Entry> SpriteToEntry { get; } = [];
 	private Dictionary<string, Entry> UniqueNameToEntry { get; } = [];
 
-	public SpriteManager()
+	public SpriteManager(IModManifest vanillaModManifest)
 	{
+		this.VanillaModManifest = vanillaModManifest;
 		SpriteLoaderPatches.OnGetTexture.Subscribe(this.OnGetTexture);
 	}
-
-	public ISpriteEntry? LookupBySpr(Spr spr) => this.SpriteToEntry.GetValueOrDefault(spr);
-
-	public ISpriteEntry? LookupByUniqueName(string uniqueName) => this.UniqueNameToEntry.GetValueOrDefault(uniqueName);
 
 	public ISpriteEntry RegisterSprite(IModManifest owner, string name, Func<Texture2D> textureProvider)
 	{
@@ -48,19 +46,23 @@ internal sealed class SpriteManager
 		return entry;
 	}
 
-	public bool TryGetByUniqueName(string uniqueName, [MaybeNullWhen(false)] out ISpriteEntry entry)
+	public ISpriteEntry? LookupBySpr(Spr spr)
 	{
-		if (this.UniqueNameToEntry.TryGetValue(uniqueName, out var typedEntry))
-		{
-			entry = typedEntry;
-			return true;
-		}
-		else
-		{
-			entry = default;
-			return false;
-		}
+		if (this.SpriteToEntry.TryGetValue(spr, out var entry))
+			return entry;
+		if (!Enum.GetValues<Spr>().Contains(spr))
+			return null;
+
+		return new Entry(
+			modOwner: this.VanillaModManifest,
+			uniqueName: Enum.GetName(spr)!,
+			sprite: spr,
+			textureProvider: () => SpriteLoader.Get(spr)!
+		);
 	}
+
+	public ISpriteEntry? LookupByUniqueName(string uniqueName)
+		=> this.UniqueNameToEntry.GetValueOrDefault(uniqueName);
 
 	private void OnGetTexture(object? _, SpriteLoaderPatches.GetTextureEventArgs e)
 	{

--- a/Nickel/Framework/Content/SpriteManager.cs
+++ b/Nickel/Framework/Content/SpriteManager.cs
@@ -17,6 +17,10 @@ internal sealed class SpriteManager
 		SpriteLoaderPatches.OnGetTexture.Subscribe(this.OnGetTexture);
 	}
 
+	public ISpriteEntry? LookupBySpr(Spr spr) => this.SpriteToEntry.GetValueOrDefault(spr);
+
+	public ISpriteEntry? LookupByUniqueName(string uniqueName) => this.UniqueNameToEntry.GetValueOrDefault(uniqueName);
+
 	public ISpriteEntry RegisterSprite(IModManifest owner, string name, Func<Texture2D> textureProvider)
 	{
 		var uniqueName = $"{owner.UniqueName}::{name}";

--- a/Nickel/Framework/Implementations/Content/ModSprites.cs
+++ b/Nickel/Framework/Implementations/Content/ModSprites.cs
@@ -44,4 +44,7 @@ internal sealed class ModSprites : IModSprites
 
 	public ISpriteEntry RegisterSprite(string name, Func<Texture2D> textureProvider)
 		=> this.SpriteManagerProvider().RegisterSprite(this.Package.Manifest, name, textureProvider);
+
+	public ISpriteEntry? LookupBySpr(Spr spr) => this.SpriteManagerProvider().LookupBySpr(spr);
+	public ISpriteEntry? LookupByUniqueName(string uniqueName) => this.SpriteManagerProvider().LookupByUniqueName(uniqueName);
 }

--- a/Nickel/Framework/Implementations/Content/ModSprites.cs
+++ b/Nickel/Framework/Implementations/Content/ModSprites.cs
@@ -30,6 +30,12 @@ internal sealed class ModSprites : IModSprites
 		return this.SpriteManagerProvider().RegisterSprite(this.Package.Manifest, spriteName, file.OpenRead);
 	}
 
+	public ISpriteEntry? LookupBySpr(Spr spr)
+		=> this.SpriteManagerProvider().LookupBySpr(spr);
+
+	public ISpriteEntry? LookupByUniqueName(string uniqueName)
+		=> this.SpriteManagerProvider().LookupByUniqueName(uniqueName);
+
 	public ISpriteEntry RegisterSprite(string name, IFileInfo file)
 		=> this.SpriteManagerProvider().RegisterSprite(this.Package.Manifest, name, file.OpenRead);
 
@@ -44,7 +50,4 @@ internal sealed class ModSprites : IModSprites
 
 	public ISpriteEntry RegisterSprite(string name, Func<Texture2D> textureProvider)
 		=> this.SpriteManagerProvider().RegisterSprite(this.Package.Manifest, name, textureProvider);
-
-	public ISpriteEntry? LookupBySpr(Spr spr) => this.SpriteManagerProvider().LookupBySpr(spr);
-	public ISpriteEntry? LookupByUniqueName(string uniqueName) => this.SpriteManagerProvider().LookupByUniqueName(uniqueName);
 }

--- a/Nickel/Interfaces/Content/IModSprites.cs
+++ b/Nickel/Interfaces/Content/IModSprites.cs
@@ -7,13 +7,12 @@ namespace Nickel;
 
 public interface IModSprites
 {
+	ISpriteEntry? LookupBySpr(Spr spr);
+	ISpriteEntry? LookupByUniqueName(string uniqueName);
 	ISpriteEntry RegisterSprite(IFileInfo file);
 	ISpriteEntry RegisterSprite(string name, IFileInfo file);
 	ISpriteEntry RegisterSprite(Func<Stream> streamProvider);
 	ISpriteEntry RegisterSprite(string name, Func<Stream> streamProvider);
 	ISpriteEntry RegisterSprite(Func<Texture2D> textureProvider);
 	ISpriteEntry RegisterSprite(string name, Func<Texture2D> textureProvider);
-
-	public ISpriteEntry? LookupBySpr(Spr spr);
-	public ISpriteEntry? LookupByUniqueName(string uniqueName);
 }

--- a/Nickel/Interfaces/Content/IModSprites.cs
+++ b/Nickel/Interfaces/Content/IModSprites.cs
@@ -13,4 +13,7 @@ public interface IModSprites
 	ISpriteEntry RegisterSprite(string name, Func<Stream> streamProvider);
 	ISpriteEntry RegisterSprite(Func<Texture2D> textureProvider);
 	ISpriteEntry RegisterSprite(string name, Func<Texture2D> textureProvider);
+
+	public ISpriteEntry? LookupBySpr(Spr spr);
+	public ISpriteEntry? LookupByUniqueName(string uniqueName);
 }


### PR DESCRIPTION
Adds methods to `IModSprites` to allow lookup `ISpriteEntry`s; similar to `IModDecks`.