### PR TITLE
Add `LocalName` property to `ISpriteEntry`

### DIFF
--- a/Nickel/Framework/Content/SpriteManager.cs
+++ b/Nickel/Framework/Content/SpriteManager.cs
@@ -24,7 +24,7 @@ internal sealed class SpriteManager
 		var uniqueName = $"{owner.UniqueName}::{name}";
 		if (this.UniqueNameToEntry.ContainsKey(uniqueName))
 			throw new ArgumentException($"A sprite with the unique name `{uniqueName}` is already registered", nameof(name));
-		return this.RegisterSprite(new(owner, uniqueName, (Spr)this.NextId++, textureProvider));
+		return this.RegisterSprite(new(owner, uniqueName, name, (Spr)this.NextId++, textureProvider));
 	}
 
 	public ISpriteEntry RegisterSprite(IModManifest owner, string name, Func<Stream> streamProvider)
@@ -32,7 +32,7 @@ internal sealed class SpriteManager
 		var uniqueName = $"{owner.UniqueName}::{name}";
 		if (this.UniqueNameToEntry.ContainsKey(uniqueName))
 			throw new ArgumentException($"A sprite with the unique name `{uniqueName}` is already registered", nameof(name));
-		return this.RegisterSprite(new(owner, uniqueName, (Spr)this.NextId++, streamProvider));
+		return this.RegisterSprite(new(owner, uniqueName, name, (Spr)this.NextId++, streamProvider));
 	}
 
 	private Entry RegisterSprite(Entry entry)
@@ -58,6 +58,7 @@ internal sealed class SpriteManager
 		return new Entry(
 			modOwner: this.VanillaModManifest,
 			uniqueName: vanillaName,
+			localName: vanillaName,
 			sprite: spr,
 			textureProvider: () => SpriteLoader.Get(spr)!
 		);
@@ -80,24 +81,27 @@ internal sealed class SpriteManager
 	{
 		public IModManifest ModOwner { get; }
 		public string UniqueName { get; }
+		public string LocalName { get; }
 		public Spr Sprite { get; }
 
 		private Func<Stream>? StreamProvider { get; set; }
 		private Func<Texture2D>? TextureProvider { get; set; }
 		private Texture2D? TextureStorage { get; set; }
 
-		public Entry(IModManifest modOwner, string uniqueName, Spr sprite, Func<Stream> streamProvider)
+		public Entry(IModManifest modOwner, string uniqueName, string localName, Spr sprite, Func<Stream> streamProvider)
 		{
 			this.ModOwner = modOwner;
 			this.UniqueName = uniqueName;
+			this.LocalName = localName;
 			this.Sprite = sprite;
 			this.StreamProvider = streamProvider;
 		}
 
-		public Entry(IModManifest modOwner, string uniqueName, Spr sprite, Func<Texture2D> textureProvider)
+		public Entry(IModManifest modOwner, string uniqueName, string localName, Spr sprite, Func<Texture2D> textureProvider)
 		{
 			this.ModOwner = modOwner;
 			this.UniqueName = uniqueName;
+			this.LocalName = localName;
 			this.Sprite = sprite;
 			this.TextureProvider = textureProvider;
 		}

--- a/Nickel/Framework/Content/SpriteManager.cs
+++ b/Nickel/Framework/Content/SpriteManager.cs
@@ -50,12 +50,14 @@ internal sealed class SpriteManager
 	{
 		if (this.SpriteToEntry.TryGetValue(spr, out var entry))
 			return entry;
-		if (!Enum.GetValues<Spr>().Contains(spr))
+
+		var vanillaName = Enum.GetName(spr);
+		if (vanillaName == null)
 			return null;
 
 		return new Entry(
 			modOwner: this.VanillaModManifest,
-			uniqueName: Enum.GetName(spr)!,
+			uniqueName: vanillaName,
 			sprite: spr,
 			textureProvider: () => SpriteLoader.Get(spr)!
 		);

--- a/Nickel/Interfaces/Content/ISpriteEntry.cs
+++ b/Nickel/Interfaces/Content/ISpriteEntry.cs
@@ -4,6 +4,7 @@ namespace Nickel;
 
 public interface ISpriteEntry : IModOwned
 {
+	string LocalName { get; }
 	Spr Sprite { get; }
 
 	Texture2D ObtainTexture();


### PR DESCRIPTION
This allows retrieving the name passed into `RegisterSprite` without manually slicing the `UniqueName`.

#### Depends on:
- [x] #72