### PR TITLE
Robustify `StreamExt::ToMemoryStream`

### DIFF
--- a/Nickel/Utilities/StreamExt.cs
+++ b/Nickel/Utilities/StreamExt.cs
@@ -15,7 +15,7 @@ public static class StreamExt
 		}
 		finally
 		{
-			if(takeOwnership)
+			if (takeOwnership)
 				stream.Dispose();
 		}
 	}

--- a/Nickel/Utilities/StreamExt.cs
+++ b/Nickel/Utilities/StreamExt.cs
@@ -4,13 +4,19 @@ namespace Nickel;
 
 public static class StreamExt
 {
-	public static MemoryStream ToMemoryStream(this Stream stream, bool closeStream = true)
+	public static MemoryStream ToMemoryStream(this Stream stream, bool takeOwnership = true)
 	{
-		MemoryStream memoryStream = new(capacity: (int)(stream.Length - stream.Position));
-		stream.CopyTo(memoryStream);
-		if (closeStream)
-			stream.Close();
-		memoryStream.Position = 0;
-		return memoryStream;
+		try
+		{
+			MemoryStream memoryStream = new(capacity: (int)(stream.Length - stream.Position));
+			stream.CopyTo(memoryStream);
+			memoryStream.Position = 0;
+			return memoryStream;
+		}
+		finally
+		{
+			if(takeOwnership)
+				stream.Dispose();
+		}
 	}
 }


### PR DESCRIPTION
Previously, if an error occurred while the stream was being copied into memory, the open Stream would leak, even if the method was employed in a way that would transfer ownership of the Stream into it.

This PR corrects this issue by ensuring that the passed stream is always closed if the second parameter is `true`, even if an exception is thrown.