### PR TITLE
Correct relatedness check in FileSystemInfoImpl`1

### DIFF
--- a/PluginManager/Implementations/Files/FileSystemInfoImpl.cs
+++ b/PluginManager/Implementations/Files/FileSystemInfoImpl.cs
@@ -44,7 +44,7 @@ public abstract class FileSystemInfoImpl<TFileSystemInfo> : IFileSystemInfo<File
 
 	public string GetRelativePathTo(IFileSystemInfo other)
 	{
-		if (other is not FileSystemInfoImpl<FileSystemInfo>)
+		if (other is not IFileSystemInfo<FileInfoImpl, DirectoryInfoImpl>)
 			throw new ArgumentException("The two file systems are unrelated to each other");
 		return Path.GetRelativePath(this.FullName, other.FullName);
 	}


### PR DESCRIPTION
> `declval<FilesystemInfoImpl<DirectoryInfoImpl>>() is not FileSystemInfoImpl<FileSystemInfo>`
> for pretty much exactly the same reason that `declval<List<SubType>>() is not List<SuperType>`

This caused spurious `ArgumentException`s when attempting to get relative paths between two on-disk files.
