### PR TITLE
Correct `RegisterSprite` relative path getting

### DIFF
--- a/Nickel/Framework/Implementations/Content/ModSprites.cs
+++ b/Nickel/Framework/Implementations/Content/ModSprites.cs
@@ -21,7 +21,7 @@ internal sealed class ModSprites : IModSprites
 		string spriteName;
 		try
 		{
-			spriteName = file.GetRelativePathTo(this.Package.PackageRoot);
+			spriteName = this.Package.PackageRoot.GetRelativePathTo(file);
 		}
 		catch
 		{


### PR DESCRIPTION
Corrects an issue where the call threw and fell into the `catch` branch, even if it shouldn't have.