### PR TITLE
Rework ModBuildConfig Assembly Handling

### DIFF
--- a/ModBuildConfig/ModBuildConfig.csproj
+++ b/ModBuildConfig/ModBuildConfig.csproj
@@ -22,6 +22,7 @@
 	<Import Project="Configuration.props.user" Condition="Exists('Configuration.props.user')" />
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Build.Utilities.Core" Version="16.11" PrivateAssets="all" />
+		<PackageReference Include="Nanoray.ExtractSingleFileApplicationResourceTask" Version="1.0.0" PrivateAssets="none" />
 	</ItemGroup>
 	<ItemGroup>
 		<None Include="$(MSBuildProjectDirectory)\..\.editorconfig" Link=".editorconfig" />

--- a/ModBuildConfig/ModBuildConfig.csproj
+++ b/ModBuildConfig/ModBuildConfig.csproj
@@ -18,11 +18,10 @@
 		<PackageReadmeFile>README.md</PackageReadmeFile>
 		<PackageLicenseFile>LICENSE</PackageLicenseFile>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-		<SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
 	</PropertyGroup>
 	<Import Project="Configuration.props.user" Condition="Exists('Configuration.props.user')" />
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Build.Utilities.Core" Version="16.11" />
+		<PackageReference Include="Microsoft.Build.Utilities.Core" Version="16.11" PrivateAssets="all" />
 	</ItemGroup>
 	<ItemGroup>
 		<None Include="$(MSBuildProjectDirectory)\..\.editorconfig" Link=".editorconfig" />

--- a/ModBuildConfig/ModBuildConfig.csproj
+++ b/ModBuildConfig/ModBuildConfig.csproj
@@ -10,6 +10,7 @@
 		<WarningsAsErrors>Nullable</WarningsAsErrors>
 		<CheckEolTargetFramework>false</CheckEolTargetFramework>
 		<IncludeBuildOutput>false</IncludeBuildOutput>
+		<NoWarn>NU5128</NoWarn>
 	</PropertyGroup>
 	<PropertyGroup>
 		<PackageId>Nickel.ModBuildConfig</PackageId>

--- a/ModBuildConfig/ModBuildConfig.csproj
+++ b/ModBuildConfig/ModBuildConfig.csproj
@@ -23,7 +23,7 @@
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Build.Utilities.Core" Version="16.11" PrivateAssets="all" />
 		<PackageReference Include="Nanoray.ExtractSingleFileApplicationResourceTask" Version="1.0.0" PrivateAssets="none" />
-		<PackageReference Include="Fayti1703.AssemblyTasks" Version="1.0.0" PrivateAssets="none" />
+		<PackageReference Include="Fayti1703.AssemblyTasks" Version="1.1.0" PrivateAssets="none" />
 	</ItemGroup>
 	<ItemGroup>
 		<None Include="$(MSBuildProjectDirectory)\..\.editorconfig" Link=".editorconfig" />

--- a/ModBuildConfig/ModBuildConfig.csproj
+++ b/ModBuildConfig/ModBuildConfig.csproj
@@ -23,6 +23,7 @@
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Build.Utilities.Core" Version="16.11" PrivateAssets="all" />
 		<PackageReference Include="Nanoray.ExtractSingleFileApplicationResourceTask" Version="1.0.0" PrivateAssets="none" />
+		<PackageReference Include="Fayti1703.AssemblyTasks" Version="1.0.0" PrivateAssets="none" />
 	</ItemGroup>
 	<ItemGroup>
 		<None Include="$(MSBuildProjectDirectory)\..\.editorconfig" Link=".editorconfig" />

--- a/ModBuildConfig/build/package.targets
+++ b/ModBuildConfig/build/package.targets
@@ -126,8 +126,14 @@
 	
 	<Target Name="PublicizeGameDll" BeforeTargets="PrepareForBuild">
 		<Fayti1703.AssemblyTasks.PublishAllTypes
+			Condition="!$(IsLegacyMod)"
 			SourceFilePath="$(GameDllPath)"
 			TargetFilePath="$(IntermediateOutputPath)/CobaltCore.dll"
+		/>
+		<Copy
+			Condition="$(IsLegacyMod)"
+			SourceFiles="$(GameDllPath)"
+			DestinationFiles="$(IntermediateOutputPath)/CobaltCore.dll"
 		/>
 	</Target>
 

--- a/ModBuildConfig/build/package.targets
+++ b/ModBuildConfig/build/package.targets
@@ -1,7 +1,6 @@
 <Project>
 	<!-- Mod build config setup start -->
 	<UsingTask TaskName="Nickel.ModBuildConfig.DeployModTask" AssemblyFile="Nickel.ModBuildConfig.dll" />
-	<UsingTask TaskName="ExtractSingleFileApplicationResourceTask" AssemblyFile="$(NuGetPackageRoot)\nanoray.extractsinglefileapplicationresourcetask\1.0.0\build\Nanoray.ExtractSingleFileApplicationResourceTask.dll" />
 	
 	<!-- Set build options -->
 	<PropertyGroup>

--- a/ModBuildConfig/build/package.targets
+++ b/ModBuildConfig/build/package.targets
@@ -120,13 +120,20 @@
 		<Message Importance="high" Condition="'$(EnableModDeploy)'" Text="ModBuildConfig: ModDeployModsPath = '$(ModDeployModsPath)'" />
 	</Target>
 
-	<Target Name="ExtractGameDllTarget" BeforeTargets="PrepareForBuild" Condition="$(EnableDllExtract)">
+	<Target Name="ExtractGameDllTarget" BeforeTargets="PublicizeGameDll" Condition="$(EnableDllExtract)">
 		<ExtractSingleFileApplicationResourceTask ExeInputPath="$(GameExePath)" ResourceName="CobaltCore.dll" ResourceOutputPath="$(GameDllPath)" />
+	</Target>
+	
+	<Target Name="PublicizeGameDll" BeforeTargets="PrepareForBuild">
+		<Fayti1703.AssemblyTasks.PublishAllTypes
+			SourceFilePath="$(GameDllPath)"
+			TargetFilePath="$(IntermediateOutputPath)/CobaltCore.dll"
+		/>
 	</Target>
 
 	<!-- Add assembly references -->
 	<ItemGroup>
-		<Reference Include="CobaltCore" Private="False" HintPath="$(GameDllPath)" IgnoreAccessChecks="true" />
+		<Reference Include="CobaltCore" Private="False" HintPath="$(IntermediateOutputPath)/CobaltCore.dll" />
 		<Reference Include="MonoGame.Framework" Private="False" HintPath="$(ModLoaderPath)\MonoGame.Framework.dll" />
 		<Reference Include="Newtonsoft.Json" Private="False" HintPath="$(ModLoaderPath)\Newtonsoft.Json.dll" />
 		<Reference Condition="!$(IsLegacyMod)" Include="0Harmony" Private="False" HintPath="$(ModLoaderPath)\0Harmony.dll" />

--- a/ModBuildConfig/build/package.targets
+++ b/ModBuildConfig/build/package.targets
@@ -120,7 +120,7 @@
 		<Message Importance="high" Condition="'$(EnableModDeploy)'" Text="ModBuildConfig: ModDeployModsPath = '$(ModDeployModsPath)'" />
 	</Target>
 
-	<Target Name="ExtractGameDllTarget" BeforeTargets="CoreCompile" Condition="$(EnableDllExtract)">
+	<Target Name="ExtractGameDllTarget" BeforeTargets="PrepareForBuild" Condition="$(EnableDllExtract)">
 		<ExtractSingleFileApplicationResourceTask ExeInputPath="$(GameExePath)" ResourceName="CobaltCore.dll" ResourceOutputPath="$(GameDllPath)" />
 	</Target>
 


### PR DESCRIPTION
This PR:
* Changes the Publicizer to `Fayti1703.AssemblyTasks.PublishAllTypes`
* Unhacks the dependency on `Nanoray.ExtractSingleFileAssemblyResourceTask`
* Ensures the game DLL is always present prior to MSBuild trying to load it (at least, according to my SDK build files)
* Disables the Publicizier in Legacy mods

Open issues:
- [x] The pack task currently complains that:
  ```
   /sdk/…/NuGet.Build.Tasks.Pack.targets(221,5): warning NU5128: Some target frameworks declared in the dependencies group of the nuspec and the lib/ref folder do not have exact matches in the other location. Consult the list of actions below: [/udata/…/Nickel/ModBuildConfig/ModBuildConfig.csproj]
   /sdk/…/NuGet.Build.Tasks.Pack.targets(221,5): warning NU5128: - Add lib or ref assemblies for the netstandard2.0 target framework [/udata/…/Nickel/ModBuildConfig/ModBuildConfig.csproj]
  ```
  I'm pretty sure we can ignore this? This seems to happen because the `lib` directory doesn't exist, but we have a `<group targetFramework=".NETStandard2.0">` in the `.nuspec` due to the declared dependencies.